### PR TITLE
Added swagger for the results endpoint

### DIFF
--- a/localstack/setup.cmd
+++ b/localstack/setup.cmd
@@ -1,7 +1,6 @@
-echo Starting localstack
+REM Keep this at the end of each AWS call: "& ^"
+REM More details here: https://stackoverflow.com/questions/4036754/why-does-only-the-first-line-of-this-windows-batch-file-execute-but-all-three-li
 docker-compose up -d
-echo Setting config file
-call aws --endpoint-url=http://localhost:4583 ssm put-parameter --name "/vote-results-dev/settings/electionsConfig" --type String --value "file://config.json" --overwrite --region "us-east-1"
-echo Setting interval for sync
-call aws --endpoint-url=http://localhost:4583 ssm put-parameter --name "/vote-results-dev/settings/intervalInSeconds" --type String --value "60" --overwrite --region "us-east-1"
+aws --endpoint-url=http://localhost:4583 ssm put-parameter --name "/vote-results-dev/settings/intervalInSeconds" --type String --value "60" --overwrite --region "us-east-1" & ^
+aws --endpoint-url=http://localhost:4583 ssm put-parameter --name "/vote-results-dev/settings/electionsConfig" --type String --value "file://config.json" --overwrite --region "us-east-1" & ^
 pause

--- a/src/ElectionResults.Core/Infrastructure/ElectionConfigurationSource.cs
+++ b/src/ElectionResults.Core/Infrastructure/ElectionConfigurationSource.cs
@@ -94,6 +94,10 @@ namespace ElectionResults.Core.Infrastructure
 
         public Result<Election> GetElectionById(string electionId)
         {
+            if (string.IsNullOrEmpty(_config?.ElectionsConfig))
+            {
+                return Result.Failure<Election>($"Could not find election with id {electionId}");
+            }
             var electionsConfig = JsonConvert.DeserializeObject<List<Election>>(_config.ElectionsConfig);
             var foundElection = electionsConfig.SingleOrDefault(e => e.ElectionId == electionId);
             if (foundElection == null)

--- a/src/ElectionResults.Core/Services/BlobContainer/BucketUploader.cs
+++ b/src/ElectionResults.Core/Services/BlobContainer/BucketUploader.cs
@@ -23,7 +23,9 @@ namespace ElectionResults.Core.Services.BlobContainer
         {
             _fileRepository = fileRepository;
             _fileProcessor = fileProcessor;
-            _httpClient = new HttpClient();
+            var httpClientHandler = new HttpClientHandler();
+            httpClientHandler.ServerCertificateCustomValidationCallback = (message, certificate2, arg3, arg4) => true;
+            _httpClient = new HttpClient(httpClientHandler);
             _config = config.Value;
         }
 

--- a/src/ElectionResults.Core/Services/ResultsAggregator.cs
+++ b/src/ElectionResults.Core/Services/ResultsAggregator.cs
@@ -106,7 +106,12 @@ namespace ElectionResults.Core.Services
 
         public async Task<Result<VoteCountStats>> GetVoteCountStatistics(string electionId)
         {
-            var election = _electionConfigurationSource.GetElectionById(electionId).Value;
+            var electionReport = _electionConfigurationSource.GetElectionById(electionId);
+            if (electionReport.IsFailure)
+            {
+                return Result.Failure<VoteCountStats>(electionReport.Error);
+            }
+            var election = electionReport.Value;
             if (election.ElectionId == Consts.FirstElectionRound)
             {
                 var stats = new VoteCountStats

--- a/src/ElectionResults.WebApi/Controllers/AdminController.cs
+++ b/src/ElectionResults.WebApi/Controllers/AdminController.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Mvc;
 namespace ElectionResults.WebApi.Controllers
 {
     [Route("api/settings")]
+    [ApiExplorerSettings(IgnoreApi = true)]
     [ApiController]
     public class AdminController : ControllerBase
     {

--- a/src/ElectionResults.WebApi/Controllers/ResultsController.cs
+++ b/src/ElectionResults.WebApi/Controllers/ResultsController.cs
@@ -28,7 +28,7 @@ namespace ElectionResults.WebApi.Controllers
         }
 
         [HttpGet("")]
-        public async Task<ActionResult<LiveResultsResponse>> GetResults([FromQuery] string electionId, string source = null, string county = null, FileType fileType = FileType.Results)
+        public async Task<ActionResult<LiveResultsResponse>> GetResults([FromQuery] string electionId = Consts.FirstElectionRound, string source = null, string county = null, FileType fileType = FileType.Results)
         {
             try
             {

--- a/src/ElectionResults.WebApi/ElectionResults.WebApi.csproj
+++ b/src/ElectionResults.WebApi/ElectionResults.WebApi.csproj
@@ -20,6 +20,7 @@
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
     <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
     <PackageReference Include="ncrontab" Version="3.3.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElectionResults.WebApi/Startup.cs
+++ b/src/ElectionResults.WebApi/Startup.cs
@@ -22,6 +22,7 @@ using IHostingEnvironment = Microsoft.AspNetCore.Hosting.IHostingEnvironment;
 using Microsoft.AspNetCore.Diagnostics;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.Logging;
+using Microsoft.OpenApi.Models;
 using Newtonsoft.Json;
 
 namespace ElectionResults.WebApi
@@ -53,7 +54,10 @@ namespace ElectionResults.WebApi
             services.AddTransient<IBucketRepository, BucketRepository>();
             services.AddTransient<IFileRepository, FileRepository>();
             services.AddTransient<IVoterTurnoutAggregator, VoterTurnoutAggregator>();
-
+            services.AddSwaggerGen(c =>
+            {
+                c.SwaggerDoc("v1", new OpenApiInfo { Title = "Rezultate Vot API", Version = "v1" });
+            });
             if (_environment.IsDevelopment())
             {
                 services.AddSingleton<IAmazonDynamoDB>(sp =>
@@ -124,7 +128,12 @@ namespace ElectionResults.WebApi
         {
             app.UseHsts();
             Log.SetLogger(loggerFactory.CreateLogger<Startup>());
+            app.UseSwagger();
 
+            app.UseSwaggerUI(c =>
+            {
+                c.SwaggerEndpoint("/swagger/v1/swagger.json", "Rezultate Vot API V1");
+            });
             app.UseCors("origins");
             app.UseExceptionHandler(errorApp =>
             {


### PR DESCRIPTION
Also ignored SSL errors because the security certificate for https://prezidentiale2019.roaep.ro has expired.