### PR TITLE
Maintenance, updated dependencies

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+# These owners will be the default owners for everything in
+# the repo. Unless a later match takes precedence,
+# they will be requested for review when someone 
+# opens a pull request.
+*       @RaduCStefanescu @bvizureanu @thewindev
+
+# More details on creating a codeowners file:
+# https://help.github.com/en/github/creating-cloning-and-archiving-repositories/about-code-owners

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,17 @@
+### Requirements for making a pull request
+
+Thank you for contributing to our project! 
+
+Please fill out the template below to help the project maintainers review it as fast as possible and include your contribution to the project.
+
+### What does it fix?
+
+Closes <!-- If it is related to an open issue, please link the issue here. -->
+
+Please mention the main changes this PR brings.
+
+### How has it been tested?
+
+Please describe the tests that you ran to verify your changes.
+
+<!-- If applicable, mention any known issues with the pull request -->

--- a/README.md
+++ b/README.md
@@ -53,7 +53,7 @@ TBD
 
 - `cd localstack`
 - Run the localstack image with docker-compose
-- `docker-compose -d`
+- `docker-compose up -d`
 - Add the required configuration settings. Use setup.cmd for Windows or setup.sh for Mac/Linux(remember to install the AWS CLI before this)
 - `.\setup.cmd`
   - this will add two settings called `electionsConfig` which is the list of elections and `intervalInSeconds` which is the background task run interval
@@ -63,7 +63,7 @@ TBD
 - `dotnet run`
 - Or, you can run the Docker image using docker-compose
 - `cd src`
-- `docker-compose -d`
+- `docker-compose up -d`
 
 
 #### Configuration

--- a/README.md
+++ b/README.md
@@ -52,16 +52,18 @@ TBD
 ##### Run the project
 
 - `cd localstack`
+- Run the localstack image with docker-compose
+- `docker-compose -d`
+- Add the required configuration settings. Use setup.cmd for Windows or setup.sh for Mac/Linux(remember to install the AWS CLI before this)
 - `.\setup.cmd`
-  - this will use the docker-compose file to pull and run the localstack image
-  - after that it will add two settings called `electionsConfig` which is the list of elections and `intervalInSeconds` which is the background task run interval
+  - this will add two settings called `electionsConfig` which is the list of elections and `intervalInSeconds` which is the background task run interval
+- use Visual Studio/Code to start the project, or use the following alternatives
+- using the dotnet CLI
 - `cd src\ElectionResults.WebApi`
-Besides Visual Studio or VS Code, you can use the command line or Docker to start the project
-- Using the dotnet CLI
-  - `dotnet run`
-- Running the Docker image
-  - `docker build --rm -f "src\Dockerfile" -t rezultatevot:latest "src" --build-arg asp_env=Development`
-  - `docker run --rm -it -p 443:443/tcp -p 80:80/tcp rezultatevot:latest`
+- `dotnet run`
+- Or, you can run the Docker image using docker-compose
+- `cd src`
+- `docker-compose -d`
 
 
 #### Configuration

--- a/localstack/setup.sh
+++ b/localstack/setup.sh
@@ -1,6 +1,5 @@
-@echo off
-REM Keep this at the end of each AWS call: "& ^"
-REM More details here: https://stackoverflow.com/questions/4036754/why-does-only-the-first-line-of-this-windows-batch-file-execute-but-all-three-li
+### Keep this at the end of each AWS call: "& ^"
+### More details here: https://stackoverflow.com/questions/4036754/why-does-only-the-first-line-of-this-windows-batch-file-execute-but-all-three-li
 
 aws --endpoint-url=http://localhost:4583 ssm put-parameter --name "/vote-results-dev/settings/intervalInSeconds" --type String --value "60" --overwrite --region "us-east-1" & ^
 aws --endpoint-url=http://localhost:4583 ssm put-parameter --name "/vote-results-dev/settings/electionsConfig" --type String --value "file://config.json" --overwrite --region "us-east-1" & ^

--- a/src/Dockerfile
+++ b/src/Dockerfile
@@ -7,7 +7,7 @@ EXPOSE 443
 
 #build
 FROM mcr.microsoft.com/dotnet/core/sdk:2.2 AS build
-RUN curl -sL https://deb.nodesource.com/setup_13.x |  bash -
+RUN curl -sL https://deb.nodesource.com/setup_14.x |  bash -
 RUN apt-get install -y nodejs
 WORKDIR /src
 COPY ["ElectionResults.WebApi/ElectionResults.WebApi.csproj", "ElectionResults.WebApi/"]

--- a/src/ElectionResults.Core/ElectionResults.Core.csproj
+++ b/src/ElectionResults.Core/ElectionResults.Core.csproj
@@ -5,15 +5,15 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="4.0.0" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.101.87" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.109.2" />
-    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.108" />
-    <PackageReference Include="CSharpFunctionalExtensions" Version="2.2.2" />
-    <PackageReference Include="CsvHelper" Version="12.2.1" />
-    <PackageReference Include="LazyCache" Version="2.0.1" />
-    <PackageReference Include="LazyCache.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="Amazon.Lambda.AspNetCoreServer" Version="5.1.1" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.106.2" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.110.68" />
+    <PackageReference Include="AWSSDK.SimpleSystemsManagement" Version="3.3.123.3" />
+    <PackageReference Include="CSharpFunctionalExtensions" Version="2.7.1" />
+    <PackageReference Include="CsvHelper" Version="15.0.5" />
+    <PackageReference Include="LazyCache" Version="2.0.4" />
+    <PackageReference Include="LazyCache.AspNetCore" Version="2.0.4" />
   </ItemGroup>
 
 </Project>

--- a/src/ElectionResults.Core/Services/CsvProcessing/CandidatesResultsParser.cs
+++ b/src/ElectionResults.Core/Services/CsvProcessing/CandidatesResultsParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -56,7 +57,8 @@ namespace ElectionResults.Core.Services.CsvProcessing
         {
             try
             {
-                var csvParser = new CsvParser(new StringReader(csvContent));
+                TextReader sr = new StringReader(csvContent);
+                var csvParser = new CsvParser(sr, CultureInfo.CurrentCulture);
                 var headers = (await csvParser.ReadAsync()).ToList();
                 var totalCanceledVotes = 0;
                 do

--- a/src/ElectionResults.Core/Services/CsvProcessing/CountyParser.cs
+++ b/src/ElectionResults.Core/Services/CsvProcessing/CountyParser.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using System.Collections.Generic;
+using System.Globalization;
 using System.IO;
 using System.Linq;
 using System.Threading.Tasks;
@@ -72,7 +73,8 @@ namespace ElectionResults.Core.Services.CsvProcessing
         protected virtual async Task<List<PollingStation>> CalculateVotesByCounty(string csvContent,
             Election election, ElectionResultsFile file)
         {
-            var csvParser = new CsvParser(new StringReader(csvContent));
+            TextReader sr = new StringReader(csvContent);
+            var csvParser = new CsvParser(sr, CultureInfo.CurrentCulture);
             var pollingStations = new List<PollingStation>();
             var headers = (await csvParser.ReadAsync()).ToList();
             do

--- a/src/ElectionResults.WebApi/ClientApp/package.json
+++ b/src/ElectionResults.WebApi/ClientApp/package.json
@@ -4,11 +4,11 @@
   "private": true,
   "dependencies": {
     "@aspnet/signalr": "^1.1.4",
-    "@atlaskit/button": "^13.3.5",
+    "@atlaskit/button": "^13.3.11",
     "bootstrap": "^4.4.1",
-    "jquery": "3.4.1",
-    "react": "^16.12.0",
-    "react-dom": "^16.12.0",
+    "jquery": "3.5.0",
+    "react": "^16.13.1",
+    "react-dom": "^16.13.1",
     "react-ga": "^2.7.0",
     "react-google-charts": "^3.0.15",
     "react-idle-timer": "^4.2.12",
@@ -18,11 +18,11 @@
     "react-select": "^3.0.8",
     "reactstrap": "^8.4.1",
     "rimraf": "^3.0.1",
-    "styled-components": "^4.4.1"
+    "styled-components": "^5.1.0"
   },
   "devDependencies": {
     "ajv": "^6.11.0",
-    "babel-eslint": "^10.0.3",
+    "babel-eslint": "^10.1.0",
     "cross-env": "^6.0.3",
     "eslint": "^6.8.0",
     "eslint-config-react-app": "^5.2.0",

--- a/src/ElectionResults.WebApi/Controllers/ResultsController.cs
+++ b/src/ElectionResults.WebApi/Controllers/ResultsController.cs
@@ -56,7 +56,8 @@ namespace ElectionResults.WebApi.Controllers
                 {
                     result.Value.PercentageCounted = 100;
                     result.Value.CanceledVotes = 182648;
-                    result.Value.TotalCountedVotes = voteCountStatisticsResult.Value.TotalCountedVotes - result.Value.CanceledVotes;
+                    if (voteCountStatisticsResult.IsSuccess)
+                        result.Value.TotalCountedVotes = voteCountStatisticsResult.Value.TotalCountedVotes - result.Value.CanceledVotes;
                     result.Value.Candidates[0].Votes = 6509135;
                     result.Value.Candidates[0].Percentage = (decimal)66.09;
                     result.Value.Candidates[1].Votes = 3339922;

--- a/src/ElectionResults.WebApi/ElectionResults.WebApi.csproj
+++ b/src/ElectionResults.WebApi/ElectionResults.WebApi.csproj
@@ -10,17 +10,17 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="AWS.Logger.AspNetCore" Version="2.1.1" />
-    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.101.87" />
+    <PackageReference Include="AWS.Logger.AspNetCore" Version="2.2.0" />
+    <PackageReference Include="AWSSDK.DynamoDBv2" Version="3.3.106.2" />
     <PackageReference Include="Amazon.Extensions.Configuration.SystemsManager" Version="1.2.0" />
-    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.100.1" />
-    <PackageReference Include="AWSSDK.S3" Version="3.3.109.2" />
-    <PackageReference Include="LazyCache.AspNetCore" Version="2.0.1" />
+    <PackageReference Include="AWSSDK.Extensions.NETCore.Setup" Version="3.3.101" />
+    <PackageReference Include="AWSSDK.S3" Version="3.3.110.68" />
+    <PackageReference Include="LazyCache.AspNetCore" Version="2.0.4" />
     <PackageReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="Microsoft.AspNetCore.Razor.Design" Version="2.2.0" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.0.0" />
+    <PackageReference Include="Microsoft.VisualStudio.Web.CodeGeneration.Design" Version="3.1.2" />
     <PackageReference Include="ncrontab" Version="3.3.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.0.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="5.4.1" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/ElectionResults.WebApi/Program.cs
+++ b/src/ElectionResults.WebApi/Program.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Net.Http;
-using Amazon;
 using Amazon.Extensions.NETCore.Setup;
 using Amazon.Runtime;
 using ElectionResults.Core.Storage;

--- a/src/ElectionResults.WebApi/Startup.cs
+++ b/src/ElectionResults.WebApi/Startup.cs
@@ -1,3 +1,4 @@
+using System;
 using Amazon;
 using Amazon.DynamoDBv2;
 using Amazon.Extensions.NETCore.Setup;
@@ -124,6 +125,8 @@ namespace ElectionResults.WebApi
             });
         }
 
+        private bool InDocker { get { return Environment.GetEnvironmentVariable("DOTNET_RUNNING_IN_CONTAINER") == "true"; } }
+
         public void Configure(IApplicationBuilder app, IHostingEnvironment env, ILoggerFactory loggerFactory)
         {
             app.UseHsts();
@@ -163,12 +166,12 @@ namespace ElectionResults.WebApi
             app.UseSpa(spa =>
             {
                 spa.Options.SourcePath = "ClientApp";
-
-                if (env.IsDevelopment())
+                if (env.IsDevelopment()) // this should be used only in Development mode
                 {
                     try
                     {
-                        spa.UseReactDevelopmentServer(npmScript: "start");
+                        if (!InDocker) // and only when started from the dotnet CLI or Visual Studio
+                            spa.UseReactDevelopmentServer(npmScript: "start");
                     }
                     catch
                     {

--- a/src/ElectionResults.WebApi/package-lock.json
+++ b/src/ElectionResults.WebApi/package-lock.json
@@ -1,0 +1,3 @@
+{
+  "lockfileVersion": 1
+}

--- a/src/docker-compose.yml
+++ b/src/docker-compose.yml
@@ -1,0 +1,13 @@
+﻿version: '3.4'
+
+services:
+  rezultatevot.api:
+    image: rezultatevot
+    build:
+      context: .
+      dockerfile: Dockerfile
+    environment:
+      - ASPNETCORE_URLS=http://+:5000
+      - ASPNETCORE_ENVIRONMENT=Development
+    ports:
+      - 5000:5000

--- a/tests/ElectionResults.Tests/ElectionResults.Tests.csproj
+++ b/tests/ElectionResults.Tests/ElectionResults.Tests.csproj
@@ -7,8 +7,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.4.0" />
+    <PackageReference Include="FluentAssertions" Version="5.10.3" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.6.1" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.1">


### PR DESCRIPTION
Updated localstack instructions. Sometimes the batch file would fail if localstack would not start immediately(which happens on the first run for example. Now the users have to:
- run docker-compose up, this will start localstack
- run the appropriate file(.cmd for Windows and .sh for Mac/Linux) to add the AWS settings in localstack
- added docker-compose file to simplify running the project, so you just need to go to the src folder and run this command and you'll have both the backend and the frontend running(in the future we should consider separating these better)
- added CODEOWNERS and PR template, please check if they are ok
- updated dependencies for npm and .net packages

resolves #107 